### PR TITLE
Add name input validation to allow only letters and spaces 

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,8 @@
             <button id="shareBtn" class="ghost-btn" title="Share result">🔗 Share</button>
           </div>
 
+          
+
           <!-- Social share buttons -->
           <div class="social-share">
             <p>Share your love result:</p>

--- a/script.js
+++ b/script.js
@@ -325,6 +325,11 @@ function makeShareableUrl(name1, name2, percent) {
   return `${base}?${params.toString()}`;
 }
 
+function isValidName(name) {
+  // Allows letters, spaces; rejects numbers, symbols
+ return /^[A-Za-z\s]+$/.test(name.trim());
+}
+
 /* ============================
    Main calculate function
    ============================ */
@@ -339,6 +344,12 @@ function calculateLove() {
     alert('Please enter both names to calculate love ✨');
     return;
   }
+
+  if (!isValidName(name1) || !isValidName(name2)) {
+    alert("Please enter valid names: letters, spaces only.");
+    return;
+  }
+
 
   // Compute numerology numbers
   const num1 = nameToNumber(name1, supportMaster);
@@ -445,6 +456,11 @@ shareBtn.addEventListener('click', (ev) => {
   const num2 = nameToNumber(name2, useMasterEl.checked);
   const combined = combineNumbers(num1, num2, useMasterEl.checked);
   const percent = mapToPercent(combined, num1, num2);
+
+    if (!isValidName(name1) || !isValidName(name2) || !name1 || !name2) {
+    alert("Please enter valid names: letters, spaces only.");
+    return;
+  }
 
   // 1) copy classic URL to clipboard (existing behaviour)
   const url = makeShareableUrl(name1, name2, percent);


### PR DESCRIPTION
This PR fixes the issue where the love calculator accepted invalid inputs such as special characters, numbers, hyphens, and apostrophes in the name fields. Now the input validation only allows alphabetic characters and spaces, improving data accuracy and user experience.  Closes #41 

Before: 
<img width="1346" height="721" alt="image" src="https://github.com/user-attachments/assets/a783c673-8c31-4183-9cba-40c00d6a87dc" />

After:
<img width="1268" height="686" alt="image" src="https://github.com/user-attachments/assets/4be3855d-8c0d-422a-9c23-cc85efe8e667" />

@Deepak-Kambala please merge this with suitable Hacktoberfest 2025 tags
