### PR TITLE
fix: add event listeners to toggle history popup visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,7 +49,6 @@ const downloadImageBtn = document.getElementById('downloadImageBtn');
 const copyImageBtn = document.getElementById('copyImageBtn');
 const nativeShareBtn = document.getElementById('nativeShareBtn');
 
-
 let confettiEnabled = true;
 let soundEnabled = false;
 
@@ -843,4 +842,12 @@ copyLinkBtn.addEventListener("click", () => {
   navigator.clipboard.writeText(window.location.href)
     .then(() => alert("Link copied to clipboard!"))
     .catch(() => alert("Failed to copy link"));
+});
+
+historyBtn.addEventListener('click', () => {
+  historyPopupOverlay.classList.remove('hidden');
+});
+
+closeHistoryPopup.addEventListener('click', () => {
+  historyPopupOverlay.classList.add('hidden');
 });

--- a/style.css
+++ b/style.css
@@ -438,7 +438,7 @@ body {
   padding: 0;
   max-width: 500px;
   width: 90%;
-  max-height: 70vh;
+  max-height: 90vh;
   box-shadow:
     0 20px 60px rgba(0, 0, 0, 0.4),
     0 0 0 1px rgba(255, 255, 255, 0.05);
@@ -549,6 +549,7 @@ body {
   margin-top: 16px;
   padding-top: 16px;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
+  gap: 10px;
 }
 
 .history-actions .outline {


### PR DESCRIPTION
## Fix: History Popup Not Opening

### Description

This PR fixes the issue (#39) where clicking the **📜 History** button did not open the popup.
The fix includes proper event listeners and ensures the overlay toggles correctly.

### Changes

* Added event listener for `#historyBtn` to open the popup
* Added event listener for `#closeHistoryPopup` to close it
* Ensured `hidden` class is toggled properly

###  Screenshot (After Fix)
<img width="1251" height="572" alt="image" src="https://github.com/user-attachments/assets/4792d1b5-c467-4483-b0bb-57a4322746e9" />

### Test Steps

1. Click on the **📜 History** button — the popup should open.
2. Click the ✕ button — the popup should close smoothly.
3. Confirm there are no console errors.

