### PR TITLE
Add Share to Instagram feature (#64)

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@
 						<a href="#" id="shareWhatsapp" target="_blank" title="Share on WhatsApp">📱 WhatsApp</a>
 						<a href="#" id="shareTwitter" target="_blank" title="Share on Twitter">🐦 Twitter</a>
 						<a href="#" id="shareFacebook" target="_blank" title="Share on Facebook">📘 Facebook</a>
+						<a href="#" id="shareInstagram" title="Share on Instagram">📷 Instagram</a>
 						<button id="copyLinkBtn" title="Copy link">🔗 Copy Link</button>
             <button id="generateLoveCard">♥️ Generate Love-Card</button>
 					</div>

--- a/script.js
+++ b/script.js
@@ -1122,6 +1122,7 @@ function drawMiniHearts(ctx, x, y) {
 const shareWhatsapp = document.getElementById('shareWhatsapp')
 const shareTwitter = document.getElementById('shareTwitter')
 const shareFacebook = document.getElementById('shareFacebook')
+const shareInstagram = document.getElementById('shareInstagram')
 const copyLinkBtn = document.getElementById('copyLinkBtn')
 
 function getShareText() {
@@ -1149,6 +1150,32 @@ shareFacebook.addEventListener('click', () => {
 	const url = encodeURIComponent(window.location.href)
 	shareFacebook.href = `https://www.facebook.com/sharer/sharer.php?u=${url}`
 })
+
+// Instagram
+shareInstagram.addEventListener('click', () => {
+    const pageUrl = window.location.href;
+
+    navigator.clipboard.writeText(pageUrl).then(() => {
+        // --- This part gives the user feedback ---
+
+        // 1. Let the user know the link was copied successfully
+        alert('Link copied! You can now paste it into your Instagram story or bio.');
+
+        // 2. (Optional) Temporarily change the button's text
+        const originalText = shareInstagram.textContent;
+        shareInstagram.textContent = 'Copied!';
+
+        // 3. Change it back after a few seconds
+        setTimeout(() => {
+            shareInstagram.textContent = originalText;
+        }, 3000); // 3000 milliseconds = 3 seconds
+
+    }).catch(err => {
+        // If it fails, log the error and inform the user
+        console.error('Failed to copy the link:', err);
+        alert('Sorry, we could not copy the link to your clipboard.');
+    });
+});
 
 // Copy Link
 copyLinkBtn.addEventListener('click', () => {


### PR DESCRIPTION
Added a “Share to Instagram” button that lets users copy the current page URL to their clipboard with one click. This allows easy sharing of Love Calculator results on Instagram stories or in the bio.

Key points:
Button added in HTML: 📷 Instagram
JavaScript handles:
Copying page URL to clipboard
Showing temporary feedback (“Copied!”)
Handling errors if copy fails