### PR TITLE
Fix text visibility due to low color contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -2726,15 +2726,15 @@ body.dark-mode .feedback-list-section {
 
 /* Panel link styling */
 .panel-link {
-	color: var(--accent1);
+	display: inline-block;
 	text-decoration: none;
 	font-weight: 500;
-	transition: all 0.2s ease;
+	transition: transform 0.3s ease, color 0.3s ease;
 }
 
 .panel-link:hover {
-	color: var(--accent2);
-	text-decoration: underline;
+	color: var(--accent3);
+	transform: scale(1.05);
 }
 
 /* Responsive */


### PR DESCRIPTION

<img width="1920" height="929" alt="Screenshot (17)" src="https://github.com/user-attachments/assets/af96e93b-fa02-4ab8-a3a6-828e040a2a46" />

Updated the .panel-link hover styles to improve visual feedback and readability:

- Changed text color on hover to var(--accent3) for better contrast.
- Added a scale transform of 1.05 on hover for subtle emphasis.
- Ensured smooth transitions for both color and transform with 0.3s ease.

Fixes #159 