### PR TITLE
fix: improve button text visibility in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -1559,13 +1559,13 @@ body.light-theme .sparkle {
 
 body.light-theme .ghost-btn {
 	background: rgba(209, 204, 204, 0.08);
-	color: #1a1a1a;
+	color: #ffffff;
 	border-color: rgba(0, 0, 0, 0.417);
 }
 
 body.light-theme .ghost-btn:hover {
 	background: rgba(0, 0, 0, 0.178);
-	color: #1a1a1a;
+	color: #ffffff;
 	border-color: rgba(0, 0, 0, 0.15);
 	transition: all 0.25s ease;
 }


### PR DESCRIPTION
In dark mode, the text inside buttons appeared grey, making it hard to read against the dark background.
I updated the button text color to white for better contrast and visibility.
Additionally, the hover state now maintains consistent readability with a clear white color.

This change improves accessibility, enhances user experience, and ensures consistent styling in dark mode.
It also serves as a meaningful contribution for Hacktoberfest 2025.

#Before
<img width="1573" height="199" alt="Screenshot 2025-10-12 211643" src="https://github.com/user-attachments/assets/c45a6ad1-279b-4745-9423-de5ea6b7a9bf" />

#After 
<img width="1523" height="203" alt="Screenshot 2025-10-12 211919" src="https://github.com/user-attachments/assets/a7ed9d09-ea22-417e-bad5-7fcc8b05d5fc" />
