### PR TITLE
fix: open quick links in a new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,8 +180,8 @@
 				<div class="panel tips-panel">
 					<h3>Quick Links</h3>
 					<ul>
-						<li><a href="about.html" class="panel-link">📖 About Love Alchemy</a></li>
-						<li><a href="how-it-works.html" class="panel-link">⚙️ How It Works</a></li>
+						<li><a href="about.html" class="panel-link" target="_blank">📖 About Love Alchemy</a></li>
+						<li><a href="how-it-works.html" class="panel-link" target="_blank">⚙️ How It Works</a></li>
 						<li>Same names → same result (unless jitter is allowed)</li>
 						<li>Share your results with friends below!</li>
 					</ul>


### PR DESCRIPTION
This pull request updates the Quick Links section so that all links open in a new browser tab (target="_blank"), improving user experience by keeping the main site open.

**Why this is needed**

Opening external or auxiliary links in a new tab prevents users from accidentally navigating away from the site, which is especially important if they are in the middle of a task.