### PR TITLE
fixed text of copy button

### DIFF
--- a/Letter/style.css
+++ b/Letter/style.css
@@ -247,7 +247,9 @@ body {
 }
 
 .btn-pixel {
-    flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     font-family: 'Press Start 2P', cursive;
     background-color: #ff66aa;
     color: #fff;
@@ -261,6 +263,7 @@ body {
     transition: all 0.1s ease-in-out;
     -webkit-font-smoothing: none;
     font-size: 0.7rem;
+    white-space: nowrap;
 }
 
 .btn-pixel:hover {
@@ -381,6 +384,11 @@ body {
     .action-buttons {
         flex-direction: column;
     }
+
+    
+    .action-buttons .btn-pixel {
+        width: 100%;
+    }
 }
 
 @media (max-width: 576px) {
@@ -400,5 +408,7 @@ body {
     .btn-pixel {
         font-size: 0.6rem;
         padding: 10px;
+        min-width: 0;
+        width: 100%;
     }
 }


### PR DESCRIPTION
text of  "copy text to clipboard" was not looking good
i fixed it

Before:
<img width="409" height="133" alt="Screenshot 2025-10-14 213825" src="https://github.com/user-attachments/assets/40134574-128d-4505-8d15-0375b83c3c75" />

After:
<img width="398" height="85" alt="Screenshot 2025-10-14 215321" src="https://github.com/user-attachments/assets/3fe93121-1b9b-4cff-a210-bb3846bdf693" />

Fix: issue #210 