### PR TITLE
light mode font color fix

### DIFF
--- a/style.css
+++ b/style.css
@@ -1349,7 +1349,7 @@ body {
 	border: 1px solid rgba(255, 255, 255, 0.04);
 	padding: 10px 12px;
 	border-radius: 10px;
-	color: var(--muted);
+	color: black;
 	cursor: pointer;
 	transition: all 0.2s ease;
 	font-size: 13px;
@@ -1827,13 +1827,13 @@ body.light-theme .sparkle {
 
 body.light-theme .ghost-btn {
 	background: rgba(209, 204, 204, 0.08);
-	color: #ffffff;
+	color: black;
 	border-color: rgba(0, 0, 0, 0.417);
 }
 
 body.light-theme .ghost-btn:hover {
 	background: rgba(0, 0, 0, 0.178);
-	color: #ffffff;
+	color: black;
 	border-color: rgba(0, 0, 0, 0.15);
 	transition: all 0.25s ease;
 }


### PR DESCRIPTION
The font color in header is fixed and now it's easily visible to the user.
<img width="914" height="97" alt="image" src="https://github.com/user-attachments/assets/84713889-8193-4885-8926-7b1d65c7d780" />

can you mark it as hacktoberfest accepted
@Deepak-Kambala Also, if you want any other changes please let me know