### PR TITLE
Add Animated Facebook Share Button with Official Colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -3393,10 +3393,6 @@ body.dark-mode .feedback-list-section {
 	background: linear-gradient(135deg, #1da1f2, #0d8bd9);
 }
 
-.share-facebook:hover {
-	background: linear-gradient(135deg, #4267b2, #365899);
-}
-
 .share-instagram:hover {
 	background: linear-gradient(135deg, #e1306c, #c13584);
 }
@@ -3850,4 +3846,94 @@ body.light-theme .download-options {
   100% {
     background-position: 400%;
   }
+}
+
+.share-facebook {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 28px;
+  font-weight: 700;
+  font-family: 'Poppins', sans-serif;
+  font-size: 1rem;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 50px;
+  cursor: pointer;
+  overflow: hidden;
+
+  /* Official Facebook blue + neon glow */
+  background: #1877f2;
+  box-shadow: 0 0 15px #1877f2, 0 0 30px #3b6ee8, 0 0 45px #00a0ff;
+
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  animation: fbPulseGlow 2s ease-in-out infinite;
+}
+
+/* Facebook icon glow + pulse */
+.facebook-icon {
+  width: 24px;
+  height: 24px;
+  color: #fff;
+  animation: fbPulse 1.2s infinite, fbSpin 4s linear infinite;
+  filter: drop-shadow(0 0 8px #3b6ee8);
+}
+
+/* Hover: scale + rotation + neon glow */
+.share-facebook:hover {
+  transform: scale(1.2) rotate(-3deg);
+  box-shadow: 0 0 30px #3b6ee8, 0 0 60px #1877f2, 0 0 90px #00a0ff;
+}
+
+/* Glimmer streak */
+.share-facebook::before {
+  content: '';
+  position: absolute;
+  top: 0; left: -100%;
+  width: 100%; height: 100%;
+  background: linear-gradient(120deg, transparent, rgba(255,255,255,0.5), transparent);
+  animation: glimmer 2s infinite;
+}
+
+/* Floating sparkle particles */
+.share-facebook::after {
+  content: '✨💙✨';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  font-size: 16px;
+  opacity: 0;
+  animation: fbParticles 3s infinite;
+}
+
+/* Keyframes */
+@keyframes fbPulseGlow {
+  0%,100% { box-shadow: 0 0 15px #1877f2, 0 0 30px #3b6ee8, 0 0 45px #00a0ff; }
+  50% { box-shadow: 0 0 25px #3b6ee8, 0 0 50px #1877f2, 0 0 75px #00a0ff; }
+}
+
+@keyframes fbPulse {
+  0%,100% { transform: scale(1); }
+  25%,75% { transform: scale(1.25); }
+  50% { transform: scale(1); }
+}
+
+@keyframes fbSpin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+@keyframes glimmer {
+  0% { left: -100%; opacity: 0; }
+  50% { left: 100%; opacity: 1; }
+  100% { left: 100%; opacity: 0; }
+}
+
+@keyframes fbParticles {
+  0%,80%,100% { transform: translate(-50%, -50%) scale(0); opacity: 0; }
+  20% { transform: translate(-50%, -120%) scale(1.2); opacity: 1; }
+  40% { transform: translate(-60%, -180%) scale(1); opacity: 0.8; }
+  60% { transform: translate(-50%, -250%) scale(0.8); opacity: 0; }
 }


### PR DESCRIPTION
- Introduced a .share-facebook button using official Facebook blue (#1877f2) with neon glow effects.
- Features pulsing and spinning Facebook icon, glimmer streak, and floating sparkle particles.
- Enhances interactivity and adds a playful, eye-catching share option for the Love Calculator website.